### PR TITLE
Don't translate GD post types/taxonomies if disabled in WPML settings - CHANGED

### DIFF
--- a/geodir_api.php
+++ b/geodir_api.php
@@ -216,6 +216,7 @@ if ( !class_exists('Geodir_REST') ) {
                 // categories
                 add_filter( 'rest_' . $post_type . 'category_collection_params', 'geodir_rest_taxonomy_collection_params', 10, 2 );
                 add_filter( 'rest_' . $post_type . 'category_query', 'geodir_rest_taxonomy_query', 10, 2 );
+                add_filter( 'rest_prepare_' . $post_type . 'category', 'geodir_rest_prepare_category_item_response', 10, 3 );
                 
                 // tags
                 add_filter( 'rest_' . $post_type . '_tags_collection_params', 'geodir_rest_taxonomy_collection_params', 10, 2 );
@@ -231,7 +232,6 @@ if ( !class_exists('Geodir_REST') ) {
                 add_filter( 'get_comment', 'geodir_rest_get_comment', 10, 1 );
                 
                 add_action( 'rest_insert_comment', array( $this, 'save_review' ), 10, 3 );
-                add_filter( 'rest_gd_placecategory_collection_params', 'geodir_rest_taxonomy_collection_params', 10, 2 );
             }
         }
         

--- a/includes/geodir-rest-listings-functions.php
+++ b/includes/geodir-rest-listings-functions.php
@@ -24,7 +24,7 @@ function geodir_rest_set_gd_var($args, $request) {
     if (empty($args['post_type'])) {
         return $args;
     }
-        
+    
     $gd_post_types = geodir_get_posttypes();
 
     if (in_array($args['post_type'], $gd_post_types)) {

--- a/includes/geodir-rest-listings-functions.php
+++ b/includes/geodir-rest-listings-functions.php
@@ -1102,7 +1102,7 @@ function geodir_rest_listing_posts_clauses_join( $join, $post_type, $query_vars 
     $table = geodir_rest_post_table( $post_type );
         
     ########### WPML ###########
-    if ( function_exists( 'icl_object_id' ) && defined( 'ICL_LANGUAGE_CODE' ) && ICL_LANGUAGE_CODE ) {
+    if ( geodir_wpml_is_post_type_translated( $post_type ) && defined( 'ICL_LANGUAGE_CODE' ) && ICL_LANGUAGE_CODE ) {
         $join .= " JOIN " . $wpdb->prefix . "icl_translations AS icl_t ON icl_t.element_id = " . $wpdb->posts . ".ID";
     }
     ########### WPML ###########

--- a/includes/geodir-rest-taxonomies-functions.php
+++ b/includes/geodir-rest-taxonomies-functions.php
@@ -12,7 +12,6 @@ if (!defined('WPINC')) {
 }
 
 function geodir_rest_taxonomy_collection_params( $params, $taxonomy ) {    
-
     // Listing location
     if ( geodir_rest_is_active( 'location' ) ) {
         $params['country'] = array(
@@ -75,4 +74,30 @@ function geodir_rest_taxonomy_query( $args, $request ) {
     }
 
     return $args;
+}
+
+/**
+ * Filters a category item returned from the API.
+ *
+ * @since 1.0.0
+ *
+ * @param WP_REST_Response  $response  The response object.
+ * @param object            $item      The original term object.
+ * @param WP_REST_Request   $request   Request used to generate the response.
+ * @return WP_REST_Response Filtered category item response.
+ */
+function geodir_rest_prepare_category_item_response( $response, $item, $request ) {
+    if ( !empty( $response->data ) && !empty( $item ) ) {
+        $post_type = substr( $item->taxonomy, 0, -8 );
+        
+        $cat_icon = geodir_get_tax_meta( $item->term_id, 'ct_cat_icon', false, $post_type );
+        $cat_icon = !empty( $cat_icon ) && isset( $cat_icon['src'] ) ? $cat_icon['src'] : '';
+        
+        $cat_image = geodir_get_default_catimage( $item->term_id, $post_type );
+        $cat_image = !empty( $cat_image ) && isset( $cat_image['src'] ) ? $cat_image['src'] : '';
+        
+        $response->data['icon'] = $cat_icon;
+        $response->data['image'] = $cat_image;
+    }
+    return $response;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ Schema added for post images to add listing images - CHANGED
 Get reviews by author endpoint changes - CHANGED
 Allow listing results to filter by latitude & longitude - CHANGED
 Subscribers should allowed to see their own reviews - FIXED
+Don't translate GD post types/taxonomies if disabled in WPML settings - CHANGED
 
 = 0.0.3 =
 Fail to get reviews when review rating addon not installed - FIXED

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Get reviews by author endpoint changes - CHANGED
 Allow listing results to filter by latitude & longitude - CHANGED
 Subscribers should allowed to see their own reviews - FIXED
 Don't translate GD post types/taxonomies if disabled in WPML settings - CHANGED
+Add category icon & default image in category response - CHANGED
 
 = 0.0.3 =
 Fail to get reviews when review rating addon not installed - FIXED


### PR DESCRIPTION
- Don't translate GD post types/taxonomies if disabled in WPML settings - CHANGED